### PR TITLE
feature: remove voter nullifier and commitment

### DIFF
--- a/circuits/ballot_proof.circom
+++ b/circuits/ballot_proof.circom
@@ -3,6 +3,7 @@ pragma circom 2.1.0;
 include "poseidon.circom";
 include "./ballot_checker.circom";
 include "./ballot_cipher.circom";
+include "./lib/vote_id.circom";
 
 // BallotProof is the circuit to prove a valid vote in the Vocdoni scheme. The 
 // vote is valid if it meets the Ballot Protocol requirements, but also if the
@@ -21,9 +22,10 @@ template BallotProof(n_fields) {
     signal input min_total_cost;    // public
     signal input cost_exp;          // public
     signal input cost_from_weight;  // public
-    signal input address;
-    signal input weight;
-    signal input process_id;
+    signal input address;           // public
+    signal input weight;            // public
+    signal input process_id;        // public
+    signal input vote_id;           // public
     // ElGamal inputs
     signal input pk[2];                         // public
     signal input k;                             // private
@@ -48,4 +50,11 @@ template BallotProof(n_fields) {
     ballotCipher.mask <== ballotProtocol.mask;
     ballotCipher.cipherfields <== cipherfields;
     ballotCipher.valid_fields === max_count;
+    // 3. Check the vote ID
+    component voteIDChecker = VoteIDChecker();
+    voteIDChecker.process_id <== process_id;
+    voteIDChecker.address <== address;
+    voteIDChecker.k <== k;
+    voteIDChecker.vote_id <== vote_id;
+
 }

--- a/circuits/ballot_proof.circom
+++ b/circuits/ballot_proof.circom
@@ -28,10 +28,6 @@ template BallotProof(n_fields) {
     signal input pk[2];                         // public
     signal input k;                             // private
     signal input cipherfields[n_fields][2][2];  // public
-    // Nullifier inputs
-    signal input nullifier;  // public
-    signal input commitment; // private
-    signal input secret;     // private
     // 1. Check the vote meets the ballot requirements
     component ballotProtocol = BallotChecker(n_fields);
     ballotProtocol.fields <== fields;
@@ -52,14 +48,4 @@ template BallotProof(n_fields) {
     ballotCipher.mask <== ballotProtocol.mask;
     ballotCipher.cipherfields <== cipherfields;
     ballotCipher.valid_fields === max_count;
-    // 3. Check the commitment and nullifier
-    component commitmentHash = Poseidon(3);
-    commitmentHash.inputs[0] <== address;
-    commitmentHash.inputs[1] <== process_id;
-    commitmentHash.inputs[2] <== secret;
-    commitmentHash.out === commitment;
-    component nullifierHash = Poseidon(2);
-    nullifierHash.inputs[0] <== commitment;
-    nullifierHash.inputs[1] <== secret;
-    nullifierHash.out === nullifier;
 }

--- a/circuits/ballot_proof_mimc.circom
+++ b/circuits/ballot_proof_mimc.circom
@@ -29,10 +29,6 @@ template BallotProof(n_fields) {
     signal input pk[2];
     signal input k;
     signal input cipherfields[n_fields][2][2];
-    // Nullifier inputs
-    signal input nullifier;
-    signal input commitment;
-    signal input secret;
     // Inputs hash
     signal input inputs_hash;
     // 0. Check the hash of the inputs (all pubprivate inputs)
@@ -52,7 +48,7 @@ template BallotProof(n_fields) {
     //  f. Address
     //  g. Commitment
     //  h. Weight
-    var static_inputs = 15; // including 2 of the pk
+    var static_inputs = 13; // including 2 of the pk
     var cipherfields_inputs = 4 * n_fields;
     var n_inputs = cipherfields_inputs + static_inputs;
     component inputs_hasher = MultiMiMC7(n_inputs, 91);
@@ -70,8 +66,6 @@ template BallotProof(n_fields) {
     inputs_hasher.in[i] <== pk[0]; i++;             // Process.EncryptionKey
     inputs_hasher.in[i] <== pk[1]; i++;             // Process.EncryptionKey
     inputs_hasher.in[i] <== address; i++;           // Vote.Address
-    inputs_hasher.in[i] <== commitment; i++;        // Vote.Commitment
-    inputs_hasher.in[i] <== nullifier; i++;         // Vote.Nullifier
     for (var f = 0; f < n_fields; f++) {
         inputs_hasher.in[i] <== cipherfields[f][0][0]; i++; // Vote.Ballot
         inputs_hasher.in[i] <== cipherfields[f][0][1]; i++; // Vote.Ballot
@@ -100,14 +94,4 @@ template BallotProof(n_fields) {
     ballotCipher.mask <== ballotProtocol.mask;
     ballotCipher.cipherfields <== cipherfields;
     ballotCipher.valid_fields === max_count;
-    // 3. Check the commitment and nullifier
-    component commitmentHash = Poseidon(3);
-    commitmentHash.inputs[0] <== address;
-    commitmentHash.inputs[1] <== process_id;
-    commitmentHash.inputs[2] <== secret;
-    commitmentHash.out === commitment;
-    component nullifierHash = Poseidon(2);
-    nullifierHash.inputs[0] <== commitment;
-    nullifierHash.inputs[1] <== secret;
-    nullifierHash.out === nullifier;
 }

--- a/circuits/ballot_proof_poseidon.circom
+++ b/circuits/ballot_proof_poseidon.circom
@@ -30,10 +30,6 @@ template BallotProof(n_fields) {
     signal input pk[2];
     signal input k;
     signal input cipherfields[n_fields][2][2];
-    // Nullifier inputs
-    signal input nullifier;
-    signal input commitment;
-    signal input secret;
     // Inputs hash signal will include all the inputs that could be public
     signal input inputs_hash;
     // 0. Check the hash of the inputs (all pubprivate inputs)
@@ -53,7 +49,7 @@ template BallotProof(n_fields) {
     //  e. Nullifier
     //  f. Commitment
     //  g. Cipherfields[n_fields][2][2]
-    var static_inputs = 15; // excluding k and secret
+    var static_inputs = 13; // excluding k and secret
     var cipherfields_inputs = 4 * n_fields;
     var n_inputs = cipherfields_inputs + static_inputs; 
     component inputs_hasher = MultiPoseidon(n_inputs);
@@ -70,8 +66,6 @@ template BallotProof(n_fields) {
     inputs_hasher.in[i] <== pk[0]; i++;             // Process.EncryptionKey
     inputs_hasher.in[i] <== pk[1]; i++;             // Process.EncryptionKey
     inputs_hasher.in[i] <== address; i++;           // Vote.Address
-    inputs_hasher.in[i] <== commitment; i++;        // Vote.Commitment
-    inputs_hasher.in[i] <== nullifier; i++;         // Vote.Nullifier
     for (var f = 0; f < n_fields; f++) {
         inputs_hasher.in[i] <== cipherfields[f][0][0]; i++; // Vote.Ballot
         inputs_hasher.in[i] <== cipherfields[f][0][1]; i++; // Vote.Ballot
@@ -100,14 +94,4 @@ template BallotProof(n_fields) {
     ballotCipher.mask <== ballotProtocol.mask;
     ballotCipher.cipherfields <== cipherfields;
     ballotCipher.valid_fields === max_count;
-    // 3. Check the commitment and nullifier
-    component commitmentHash = Poseidon(3);
-    commitmentHash.inputs[0] <== address;
-    commitmentHash.inputs[1] <== process_id;
-    commitmentHash.inputs[2] <== secret;
-    commitmentHash.out === commitment;
-    component nullifierHash = Poseidon(2);
-    nullifierHash.inputs[0] <== commitment;
-    nullifierHash.inputs[1] <== secret;
-    nullifierHash.out === nullifier;
 }

--- a/circuits/lib/vote_id.circom
+++ b/circuits/lib/vote_id.circom
@@ -1,10 +1,11 @@
 pragma circom 2.1.0;
 
+include "bitify.circom";
 include "mimc.circom";
 
 // VoteIDChecker is a circuit to check the validity of a vote ID. A valid vote 
 // ID is the mimc7 hash of the process ID, the address and the secret k of the 
-// voter.
+// voter, truncated to 160 bits (20 bytes).
 template VoteIDChecker() {
     signal input process_id;  // public
     signal input address;     // public
@@ -16,6 +17,16 @@ template VoteIDChecker() {
     hasher.in[0] <== process_id;
     hasher.in[1] <== address;
     hasher.in[2] <== k;
+    // bit decomposition of the hash output
+    component bits = Num2Bits(254);
+    bits.in <== hasher.out;
+    // reconstruct the lowest 160 bits as the truncated hash
+    signal res[161];
+    res[0] <== 0;  // accumulator starts at 0
+    // signal partials[160];
+    for (var i = 0; i < 160; i++) {
+        res[i+1] <== res[i] + (bits.out[i] * (1 << i));
+    }
     // ensure that the output is the expected vote ID
-    hasher.out === vote_id;
+    res[160] === vote_id;
 }

--- a/circuits/lib/vote_id.circom
+++ b/circuits/lib/vote_id.circom
@@ -1,0 +1,21 @@
+pragma circom 2.1.0;
+
+include "mimc.circom";
+
+// VoteIDChecker is a circuit to check the validity of a vote ID. A valid vote 
+// ID is the mimc7 hash of the process ID, the address and the secret k of the 
+// voter.
+template VoteIDChecker() {
+    signal input process_id;  // public
+    signal input address;     // public
+    signal input k;           // private
+    signal input vote_id;    // public
+    // calculate the vote ID using mimc7 hash
+    component hasher = MultiMiMC7(3, 91);
+    hasher.k <== 0;
+    hasher.in[0] <== process_id;
+    hasher.in[1] <== address;
+    hasher.in[2] <== k;
+    // ensure that the output is the expected vote ID
+    hasher.out === vote_id;
+}

--- a/test/ballot_proof_mimc_test.go
+++ b/test/ballot_proof_mimc_test.go
@@ -27,6 +27,8 @@ func TestBallotProofMiMC(t *testing.T) {
 		return
 	}
 	var (
+		address   = acc.Address().Bytes()
+		processID = util.RandomBytes(20)
 		// ballot inputs
 		n_fields        = 8
 		maxCount        = 5
@@ -37,10 +39,6 @@ func TestBallotProofMiMC(t *testing.T) {
 		costExp         = 2
 		costFromWeight  = 0
 		weight          = 0
-		// nullifier inputs
-		address   = acc.Address().Bytes()
-		processID = util.RandomBytes(20)
-		secret    = util.RandomBytes(16)
 		// circuit assets
 		wasmFile = "../artifacts/ballot_proof_mimc_test.wasm"
 		zkeyFile = "../artifacts/ballot_proof_mimc_test_pkey.zkey"
@@ -55,12 +53,6 @@ func TestBallotProofMiMC(t *testing.T) {
 	}
 	// encrypt ballot fields and get them in plain format
 	cipherfields, plainCipherfields := utils.CipherBallotFields(fields, n_fields, pubKey, k)
-	// generate the nullifier
-	commitment, nullifier, err := utils.MockedCommitmentAndNullifier(address, processID, secret)
-	if err != nil {
-		log.Fatalf("Error hashing: %v\n", err)
-		return
-	}
 	bigInputs := []*big.Int{
 		util.BigToFF(new(big.Int).SetBytes(processID)),
 		big.NewInt(int64(maxCount)),
@@ -74,8 +66,6 @@ func TestBallotProofMiMC(t *testing.T) {
 		pubKey.X,
 		pubKey.Y,
 		util.BigToFF(new(big.Int).SetBytes(address)),
-		commitment,
-		nullifier,
 	}
 	bigInputs = append(bigInputs, plainCipherfields...)
 	bigInputs = append(bigInputs, big.NewInt(int64(weight)))
@@ -101,9 +91,6 @@ func TestBallotProofMiMC(t *testing.T) {
 		"pk":               []string{pubKey.X.String(), pubKey.Y.String()},
 		"k":                k.String(),
 		"cipherfields":     cipherfields,
-		"nullifier":        nullifier.String(),
-		"commitment":       commitment.String(),
-		"secret":           util.BigToFF(new(big.Int).SetBytes(secret)).String(),
 		"inputs_hash":      inputsHash.String(),
 	}
 	bInputs, _ := json.MarshalIndent(inputs, "  ", "  ")

--- a/test/ballot_proof_poseidon_test.go
+++ b/test/ballot_proof_poseidon_test.go
@@ -26,6 +26,8 @@ func TestBallotProofPoseidon(t *testing.T) {
 		return
 	}
 	var (
+		address   = acc.Address().Bytes()
+		processID = util.RandomBytes(20)
 		// ballot inputs
 		fields          = utils.GenerateBallotFields(5, 16, 0, false)
 		n_fields        = 8
@@ -36,10 +38,6 @@ func TestBallotProofPoseidon(t *testing.T) {
 		costExp         = 2
 		costFromWeight  = 0
 		weight          = 0
-		// nullifier inputs
-		address   = acc.Address().Bytes()
-		processID = util.RandomBytes(20)
-		secret    = util.RandomBytes(16)
 		// circuit assets
 		wasmFile = "../artifacts/ballot_proof_poseidon_test.wasm"
 		zkeyFile = "../artifacts/ballot_proof_poseidon_test_pkey.zkey"
@@ -54,12 +52,6 @@ func TestBallotProofPoseidon(t *testing.T) {
 	}
 	// encrypt ballot fields and get them in plain format
 	cipherfields, plainCipherfields := utils.CipherBallotFields(fields, n_fields, pubKey, k)
-	// generate the commitment and nullifier
-	commitment, nullifier, err := utils.MockedCommitmentAndNullifier(address, processID, secret)
-	if err != nil {
-		log.Fatalf("Error hashing: %v\n", err)
-		return
-	}
 	bigInputs := []*big.Int{
 		util.BigToFF(new(big.Int).SetBytes(processID)),
 		big.NewInt(int64(maxCount)),
@@ -73,8 +65,6 @@ func TestBallotProofPoseidon(t *testing.T) {
 		pubKey.X,
 		pubKey.Y,
 		util.BigToFF(new(big.Int).SetBytes(address)),
-		commitment,
-		nullifier,
 	}
 	bigInputs = append(bigInputs, plainCipherfields...)
 	bigInputs = append(bigInputs, big.NewInt(int64(weight)))
@@ -100,9 +90,6 @@ func TestBallotProofPoseidon(t *testing.T) {
 		"pk":               []string{pubKey.X.String(), pubKey.Y.String()},
 		"k":                k.String(),
 		"cipherfields":     cipherfields,
-		"nullifier":        nullifier.String(),
-		"commitment":       commitment.String(),
-		"secret":           util.BigToFF(new(big.Int).SetBytes(secret)).String(),
 		"inputs_hash":      inputsHash.String(),
 	}
 	bInputs, _ := json.MarshalIndent(inputs, "  ", "  ")

--- a/test/ballot_proof_test.circom
+++ b/test/ballot_proof_test.circom
@@ -2,4 +2,4 @@ pragma circom 2.1.0;
 
 include "../circuits/ballot_proof.circom";
 
-component main{public [max_count, force_uniqueness, max_value, min_value, max_total_cost, min_total_cost, cost_exp, cost_from_weight, weight, cipherfields]} = BallotProof(8);
+component main{public [max_count, force_uniqueness, max_value, min_value, max_total_cost, min_total_cost, cost_exp, cost_from_weight, address, process_id, vote_id, weight, cipherfields]} = BallotProof(8);

--- a/test/ballot_proof_test.circom
+++ b/test/ballot_proof_test.circom
@@ -2,4 +2,4 @@ pragma circom 2.1.0;
 
 include "../circuits/ballot_proof.circom";
 
-component main{public [max_count, force_uniqueness, max_value, min_value, max_total_cost, min_total_cost, cost_exp, cost_from_weight, weight, cipherfields, nullifier]} = BallotProof(8);
+component main{public [max_count, force_uniqueness, max_value, min_value, max_total_cost, min_total_cost, cost_exp, cost_from_weight, weight, cipherfields]} = BallotProof(8);

--- a/test/ballot_proof_test.go
+++ b/test/ballot_proof_test.go
@@ -58,6 +58,13 @@ func TestBallotProof(t *testing.T) {
 		return
 	}
 	cipherfields, _ := utils.CipherBallotFields(fields, n_fields, pubKey, k)
+	bigPID := util.BigToFF(new(big.Int).SetBytes(processID))
+	bigAddr := util.BigToFF(new(big.Int).SetBytes(address))
+	voteID, err := utils.VoteID(bigPID, bigAddr, k)
+	if err != nil {
+		t.Errorf("Error generating vote ID: %v\n", err)
+		return
+	}
 	// circuit inputs
 	inputs := map[string]any{
 		"fields":           utils.BigIntArrayToStringArray(fields, n_fields),
@@ -73,8 +80,9 @@ func TestBallotProof(t *testing.T) {
 		"pk":               []string{pubKey.X.String(), pubKey.Y.String()},
 		"k":                k.String(),
 		"cipherfields":     cipherfields,
-		"address":          util.BigToFF(new(big.Int).SetBytes(address)).String(),
-		"process_id":       util.BigToFF(new(big.Int).SetBytes(processID)).String(),
+		"address":          bigAddr.String(),
+		"process_id":       bigPID.String(),
+		"vote_id":          voteID.String(),
 	}
 	bInputs, _ := json.MarshalIndent(inputs, "  ", "  ")
 	t.Log("Inputs:", string(bInputs))
@@ -97,11 +105,11 @@ func TestBallotProof(t *testing.T) {
 	}
 	log.Println("Proof verified")
 	if persist {
-		if err := os.WriteFile(fmt.Sprintf("./%s_proof.json", testID), []byte(proofData), 0644); err != nil {
+		if err := os.WriteFile(fmt.Sprintf("./%s_proof.json", testID), []byte(proofData), 0o644); err != nil {
 			t.Errorf("Error writing proof file: %v\n", err)
 			return
 		}
-		if err := os.WriteFile(fmt.Sprintf("./%s_pub_signals.json", testID), []byte(pubSignals), 0644); err != nil {
+		if err := os.WriteFile(fmt.Sprintf("./%s_pub_signals.json", testID), []byte(pubSignals), 0o644); err != nil {
 			t.Errorf("Error writing public signals file: %v\n", err)
 			return
 		}

--- a/test/ts/ballot_proof_poseidon_test.ts
+++ b/test/ts/ballot_proof_poseidon_test.ts
@@ -1,4 +1,4 @@
-import { bigIntToField, hexToField, strToBigInt, hash, multiHash, encrypt, prove, verify } from './utils';
+import { hexToField, multiHash, encrypt, prove, verify } from './utils';
 
 (async () => {
     const wasm = "../../artifacts/ballot_proof_poseidon_test.wasm";
@@ -27,16 +27,6 @@ import { bigIntToField, hexToField, strToBigInt, hash, multiHash, encrypt, prove
     // compute nullifier
     const address = hexToField("0x6Db989fbe7b1308cc59A27f021e2E3de9422CF0A");
     const process_id = hexToField("0xf16236a51F11c0Bf97180eB16694e3A345E42506");
-    const secret = "super-secret-mnemonic-phrase";
-    const commitment = hash([
-        address,
-        process_id,
-        bigIntToField(strToBigInt(secret)),
-    ]);
-    const nullifier = hash([
-        commitment,
-        bigIntToField(strToBigInt(secret)),
-    ]);
     // init inputs
     const inputs = {
         fields,
@@ -54,9 +44,6 @@ import { bigIntToField, hexToField, strToBigInt, hash, multiHash, encrypt, prove
         k,
         cipherfields,
         address,
-        nullifier,
-        commitment,
-        secret: bigIntToField(strToBigInt(secret)),
         inputs_hash: BigInt(0)
     };
     const bigFields : bigint[] = [];
@@ -83,8 +70,6 @@ import { bigIntToField, hexToField, strToBigInt, hash, multiHash, encrypt, prove
         inputs.pk[0],
         inputs.pk[1],
         address,
-        inputs.commitment,
-        inputs.nullifier,
         ...plainBigCipherFields,
         BigInt(inputs.weight),
     ]);

--- a/test/ts/ballot_proof_test.ts
+++ b/test/ts/ballot_proof_test.ts
@@ -1,4 +1,4 @@
-import { bigIntToField, hexToField, strToBigInt, hash, encrypt, prove, verify } from './utils';
+import { encrypt, prove, verify } from './utils';
 
 (async () => {
     const wasm = "../../artifacts/ballot_proof_test.wasm";
@@ -27,16 +27,6 @@ import { bigIntToField, hexToField, strToBigInt, hash, encrypt, prove, verify } 
     // compute nullifier
     const address = "0x6Db989fbe7b1308cc59A27f021e2E3de9422CF0A";
     const process_id = "0xf16236a51F11c0Bf97180eB16694e3A345E42506";
-    const secret = "super-secret-mnemonic-phrase";
-    const commitment = hash([
-        hexToField(address),
-        hexToField(process_id),
-        bigIntToField(strToBigInt(secret)),
-    ]);
-    const nullifier = hash([
-        commitment,
-        bigIntToField(strToBigInt(secret)),
-    ]);
     // init inputs
     const inputs = {
         fields,
@@ -52,9 +42,8 @@ import { bigIntToField, hexToField, strToBigInt, hash, encrypt, prove, verify } 
         pk: pubKey,
         k,
         cipherfields,
-        nullifier,
-        commitment,
-        secret: bigIntToField(strToBigInt(secret)),
+        address,
+        process_id,
     };
     console.log("inputs", inputs);
     // generate proof

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -6,7 +6,9 @@ import (
 	"math/big"
 
 	"github.com/iden3/go-iden3-crypto/babyjub"
+	"github.com/iden3/go-iden3-crypto/mimc7"
 	"github.com/iden3/go-iden3-crypto/poseidon"
+	"go.vocdoni.io/dvote/util"
 )
 
 func BigIntArrayToN(arr []*big.Int, n int) []*big.Int {
@@ -76,4 +78,12 @@ func MultiPoseidon(inputs ...*big.Int) (*big.Int, error) {
 	}
 	// return the hash of all chunk hashes
 	return poseidon.Hash(hashes)
+}
+
+func VoteID(bigPID, bigAddr, k *big.Int) (*big.Int, error) {
+	return mimc7.Hash([]*big.Int{
+		util.BigToFF(bigPID),
+		util.BigToFF(bigAddr),
+		util.BigToFF(k),
+	}, nil)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -81,9 +81,19 @@ func MultiPoseidon(inputs ...*big.Int) (*big.Int, error) {
 }
 
 func VoteID(bigPID, bigAddr, k *big.Int) (*big.Int, error) {
-	return mimc7.Hash([]*big.Int{
+	hash, err := mimc7.Hash([]*big.Int{
 		util.BigToFF(bigPID),
 		util.BigToFF(bigAddr),
 		util.BigToFF(k),
 	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate vote ID: %v", err)
+	}
+	return TruncateTo160Bits(hash), nil
+}
+
+func TruncateTo160Bits(input *big.Int) *big.Int {
+	mask := new(big.Int).Lsh(big.NewInt(1), 160) // 1 << 160
+	mask.Sub(mask, big.NewInt(1))                // (1 << 160) - 1
+	return new(big.Int).And(input, mask)         // input & ((1<<160)-1)
 }


### PR DESCRIPTION
This PR contains the following changes:
* Removes the commitment and nullifier calculation and comparison.
* Includes the calculation and comparison of the `voteID` (which follows the formula `mimc7(processID, address, k)`.